### PR TITLE
Accumulate local contributions inside pmix server-side.

### DIFF
--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -34,6 +34,7 @@ typedef struct {
     pmix_range_t *ranges;
     size_t nranges;
     pmix_list_t locals;
+    uint32_t local_cnt;
     pmix_list_t *trklist;
 } pmix_server_trkr_t;
 OBJ_CLASS_DECLARATION(pmix_server_trkr_t);


### PR DESCRIPTION
Fix server API code to properly handle local contributions to fence.
Previously server fence callback was called at time of first
contribution.
Now server will wait for all local processes to contribute to the fence
before notifying resource manager.
The reason why this was left unnoticed is that when PMIx_Get was called
for other processes server was able to detect that requested data is
missing and delay responce.