### PR TITLE
Remove "#include <event.h>" from pmix header files.

### DIFF
--- a/src/api/pmix_common.h.in
+++ b/src/api/pmix_common.h.in
@@ -51,7 +51,6 @@
 #ifdef HAVE_SYS_TIME_H
 #include <sys/time.h> /* for struct timeval */
 #endif
-#include <event.h>
 
 #ifndef PMIX_CONFIG_H
 

--- a/src/api/pmix_server.h
+++ b/src/api/pmix_server.h
@@ -74,7 +74,6 @@
 #ifdef HAVE_NET_UIO_H
 #include <net/uio.h>
 #endif
-#include <event.h>
 
 #include "pmix_common.h"
 


### PR DESCRIPTION
Presense of this file corrupt compilation if using
lite version of server API.