### PR TITLE
Provide more flexible client setup at fork. 

### DIFF
--- a/src/api/pmix_server.h
+++ b/src/api/pmix_server.h
@@ -273,6 +273,14 @@ pmix_status_t PMIx_server_setup_job(const char nspace[],
 pmix_status_t PMIx_server_setup_fork(const char nspace[], int rank,
                                      uid_t uid, gid_t gid, char ***env);
 
+typedef int (*pmix_setenv_cb_t)(char ***array_ptr, const char *name,
+                                const char *value);
+/* Same as PMIx_server_setup_fork but uses provided function
+ * to set the environment instead of pmix_setenv. */
+pmix_status_t PMIx_server_setup_fork_fn(const char nspace[], int rank,
+                                        uid_t uid, gid_t gid, char ***env,
+                                        pmix_setenv_cb_t setenv_cb);
+
 
 /****    Message processing for the "lite" version of the  ****
  ****    server convenience library. Note that we must     ****


### PR DESCRIPTION
Add PMIx_server_setup_fork_fn function that can use external callback to set
environment variable.
For example in SLURM setup of new client is done in stepd environment
and one has a pointer to the future client environment.