### PR TITLE
pmix tests modifications

### DIFF
--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -47,7 +47,7 @@ void cli_connect(cli_info_t *cli, int sd, struct event_base * ebase, event_callb
                       EV_READ|EV_PERSIST, callback, cli);
     event_add(cli->ev,NULL);
     pmix_usock_set_nonblocking(sd);
-    TEST_OUTPUT(("Connection accepted from rank %d", cli_rank(cli) ));
+    TEST_VERBOSE(("Connection accepted from rank %d", cli_rank(cli) ));
     cli->state = CLI_CONNECTED;
 }
 

--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -27,6 +27,7 @@ typedef struct {
     pmix_event_t *ev;
     cli_state_t state;
     cli_state_t state_order[CLI_TERM+1];
+    int status; /* 0 - successfully finished, 1 - otherwise */
 } cli_info_t;
 
 extern cli_info_t *cli_info;
@@ -43,7 +44,7 @@ void cli_cleanup(cli_info_t *cli);
 void cli_wait_all(double timeout);
 void cli_kill_all(void);
 
-bool test_completed(void);
+bool test_succeeded(void);
 bool test_terminated(void);
 
 void errhandler(pmix_status_t status,

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
     }
 
     /* hang around until the client(s) finalize */
-    while (!test_completed()) {
+    while (!test_terminated()) {
         // To avoid test hang we want to interrupt the loop each 0.1s
         double test_current;
 
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
         cli_wait_all(0);
     }
 
-    if( !test_completed() ){
+    if( !test_terminated() ){
         TEST_ERROR(("Test exited by a timeout!"));
         cli_kill_all();
     }
@@ -207,15 +207,14 @@ int main(int argc, char **argv)
         TEST_ERROR(("Finalize failed with error %d", rc));
     }
 
-    if( !test_terminated() ){
+    if (!test_abort && !test_succeeded()) {
         int i;
-        // All clients should disconnect
-        TEST_ERROR(("Error while cleaning up test. Expect state = %d:", CLI_TERM));
-        for(i=0; i < cli_info_cnt; i++){
-            TEST_ERROR(("\trank %d, state = %d", i, cli_info[i].state));
+        // All of the client should deisconnect
+        TEST_ERROR(("Test failed. Some of processes didn't call PMIX_Finalize."));
+        for (i = 0; i < cli_info_cnt; i++) {
+            TEST_ERROR(("\trank %d, status = %d", i, cli_info[i].status));
         }
-
-    } else {
+    } else if (!test_abort) {
         TEST_OUTPUT(("Test finished OK!"));
     }
 

--- a/test/pmix_test_lite.c
+++ b/test/pmix_test_lite.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2006-2013 Los Alamos National Security, LLC. 
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
@@ -57,7 +57,6 @@ int main(int argc, char **argv)
     int test_timeout = TEST_DEFAULT_TIMEOUT;
     struct timeval tv;
     double test_start;
-    bool verbose = false;
     char *ranks = NULL;
 
     gettimeofday(&tv, NULL);
@@ -68,9 +67,9 @@ int main(int argc, char **argv)
         TEST_ERROR(("ERROR IN COMPUTING CONSTANTS: PMIX_SUCCESS = %d\n", PMIX_SUCCESS));
         exit(1);
     }
-  
+
     parse_cmd(argc, argv, &binary, &np, &test_timeout);
-    TEST_OUTPUT(("Start PMIx_lite smoke test (timeout is %d)", test_timeout));
+    TEST_VERBOSE(("Start PMIx_lite smoke test (timeout is %d)", test_timeout));
 
     /* verify executable */
     if( 0 > ( rc = stat(binary, &stat_buf) ) ){
@@ -110,7 +109,7 @@ int main(int argc, char **argv)
         TEST_ERROR(("Cannot create libevent event\n"));
         goto cleanup;
     }
-    
+
     /* retrieve the rendezvous address */
     if (PMIX_SUCCESS != PMIx_get_rendezvous_address(&address, NULL)) {
         TEST_ERROR(("failed to get rendezvous address"));
@@ -118,7 +117,7 @@ int main(int argc, char **argv)
         goto cleanup;
     }
 
-    TEST_OUTPUT(("Initialization finished"));
+    TEST_VERBOSE(("Initialization finished"));
 
     /* start listening */
     if( 0 > (listen_fd = start_listening(&address) ) ){
@@ -127,11 +126,17 @@ int main(int argc, char **argv)
     }
 
     client_env = pmix_argv_copy(environ);
-    
+
     /* fork/exec the test */
     pmix_argv_append_nosize(&client_argv, binary);
+    if (nonblocking) {
+        pmix_argv_append_nosize(&client_argv, "-nb");
+        if (barrier) {
+            pmix_argv_append_nosize(&client_argv, "-b");
+        }
+    }
     if (collect) {
-        pmix_argv_append_nosize(&client_argv, "collect");
+        pmix_argv_append_nosize(&client_argv, "-c");
     }
     pmix_argv_append_nosize(&client_argv, "-n");
     if (NULL == np) {
@@ -139,18 +144,22 @@ int main(int argc, char **argv)
     } else {
         pmix_argv_append_nosize(&client_argv, np);
     }
-
     if( verbose ){
         pmix_argv_append_nosize(&client_argv, "-v");
     }
+    if (NULL != out_file) {
+        pmix_argv_append_nosize(&client_argv, "-o");
+        pmix_argv_append_nosize(&client_argv, out_file);
+        free(out_file);
+    }
 
     tmp = pmix_argv_join(client_argv, ' ');
-    TEST_OUTPUT(("Executing test: %s", tmp));
+    TEST_VERBOSE(("Executing test: %s", tmp));
     free(tmp);
 
     myuid = getuid();
     mygid = getgid();
-    
+
     int order[CLI_TERM+1];
     order[CLI_UNINIT] = CLI_FORKED;
     order[CLI_FORKED] = CLI_CONNECTED;
@@ -177,7 +186,7 @@ int main(int argc, char **argv)
 //        for (i=0; NULL != client_env[i]; i++) {
 //            TEST_VERBOSE(("env[%d]: %s", i, client_env[i]));
 //        }
-    
+
         cli_info[n].pid = fork();
         if (cli_info[n].pid < 0) {
             TEST_ERROR(("Fork failed"));
@@ -185,7 +194,7 @@ int main(int argc, char **argv)
             cli_kill_all();
             return -1;
         }
-        
+
         if (cli_info[n].pid == 0) {
             execve(binary, client_argv, client_env);
             /* Does not return */
@@ -223,10 +232,10 @@ int main(int argc, char **argv)
         cli_kill_all();
     }
 
-    
+
     pmix_argv_free(client_argv);
     pmix_argv_free(client_env);
-    
+
     /* deregister the errhandler */
     PMIx_Deregister_errhandler();
 
@@ -269,30 +278,30 @@ static int start_listening(struct sockaddr_un *address)
     /* create a listen socket for incoming connection attempts */
     listen_fd = socket(PF_UNIX, SOCK_STREAM, 0);
     if (listen_fd < 0) {
-        TEST_OUTPUT(("socket() failed"));
+        TEST_ERROR(("socket() failed"));
         return -1;
     }
 
     addrlen = sizeof(struct sockaddr_un);
     if (bind(listen_fd, (struct sockaddr*)address, addrlen) < 0) {
-        TEST_OUTPUT(("bind() failed"));
+        TEST_ERROR(("bind() failed"));
         return -1;
     }
 
     /* setup listen backlog to maximum allowed by kernel */
     if (listen(listen_fd, SOMAXCONN) < 0) {
-        TEST_OUTPUT(("listen() failed"));
+        TEST_ERROR(("listen() failed"));
         return -1;
     }
-        
+
     /* set socket up to be non-blocking, otherwise accept could block */
     if ((flags = fcntl(listen_fd, F_GETFL, 0)) < 0) {
-        TEST_OUTPUT(("fcntl(F_GETFL) failed"));
+        TEST_ERROR(("fcntl(F_GETFL) failed"));
         return -1;
     }
     flags |= O_NONBLOCK;
     if (fcntl(listen_fd, F_SETFL, flags) < 0) {
-        TEST_OUTPUT(("fcntl(F_SETFL) failed"));
+        TEST_ERROR(("fcntl(F_SETFL) failed"));
         return -1;
     }
 
@@ -300,7 +309,7 @@ static int start_listening(struct sockaddr_un *address)
     listen_ev = event_new(server_base, listen_fd,
                           EV_READ|EV_PERSIST, connection_handler, 0);
     event_add(listen_ev, 0);
-    TEST_OUTPUT(("Server is listening for incoming connections"));
+    TEST_VERBOSE(("Server is listening for incoming connections"));
     return 0;
 }
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -33,19 +33,21 @@ extern int collect;
 extern int nonblocking;
 extern uint32_t nprocs;
 extern int verbose;
+extern char *out_file;
+extern FILE *file;
 
 #define STRIPPED_FILE_NAME (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
 
 #define TEST_OUTPUT(x) { \
-    fprintf(stderr,"%s:%s: %s\n",STRIPPED_FILE_NAME, __FUNCTION__, \
+    fprintf((NULL == file) ? stderr : file,"%s:%s: %s\n",STRIPPED_FILE_NAME, __FUNCTION__, \
             pmix_test_output_prepare x ); \
-    fflush(stderr); \
+    fflush((NULL == file) ? stderr : file); \
 }
 
 #define TEST_ERROR(x) { \
-    fprintf(stderr,"ERROR [%s:%d:%s]: %s\n", STRIPPED_FILE_NAME, __LINE__, __FUNCTION__, \
+    fprintf((NULL == file) ? stderr : file,"ERROR [%s:%d:%s]: %s\n", STRIPPED_FILE_NAME, __LINE__, __FUNCTION__, \
             pmix_test_output_prepare x ); \
-    fflush(stderr); \
+    fflush((NULL == file) ? stderr : file); \
 }
 
 #define TEST_VERBOSE_ON() (pmix_test_verbose = 1)
@@ -57,6 +59,8 @@ extern int verbose;
 }
 
 #define TEST_DEFAULT_TIMEOUT 10
+#define MAX_DIGIT_LEN 10
+
 void parse_cmd(int argc, char **argv, char **binary, char **np, int *timeout);
 
 #endif // TEST_COMMON_H

--- a/test/utils.h
+++ b/test/utils.h
@@ -4,8 +4,6 @@
 #include <unistd.h>
 #include <stdint.h>
 
-#define MAX_DIGIT_LEN 5
-
 void fill_seq_ranks_array(size_t nprocs, char **ranks);
 void set_namespace(int nprocs, char *ranks, char *name);
 


### PR DESCRIPTION
1 commit: added -o (logging to file) option for clients; disabled logging by default; do not call PMIX_Finalize in case of error to track it by server
2 commit: make servers track incorrect client's termination and treat abort as a failure. There is over complicated logic, I will take a look once again next week to optimize it.