### PR TITLE
Pmix tests updates

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,7 +19,7 @@
 # $HEADER$
 #
 
-headers = test_common.h cli_stages.h server_callbacks.h utils.h
+headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
@@ -55,7 +55,7 @@ pmi2_client_LDADD = \
 	$(top_builddir)/libpmix.la
 
 pmix_client_SOURCES = \
-        pmix_client.c test_common.c
+        pmix_client.c test_fence.c test_common.c
 
 pmix_client_LDADD = \
 	$(top_builddir)/libpmix.la

--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -30,6 +30,8 @@ void cli_init(int nprocs, int order[])
         for (i = 0; i < CLI_TERM+1; i++) {
             cli_info[n].next_state[i] = order[i];
         }
+        cli_info[n].rank = -1;
+        cli_info[n].ns = NULL;
     }
 }
 
@@ -105,6 +107,9 @@ void cli_terminate(cli_info_t *cli)
     cli->pid = -1;
     TEST_VERBOSE(("Client rank = %d terminated", cli_rank(cli)));
     cli->state = CLI_TERM;
+    if (NULL != cli->ns) {
+        free(cli->ns);
+    }
 }
 
 void cli_cleanup(cli_info_t *cli)

--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -27,6 +27,8 @@ typedef struct {
     pmix_event_t *ev;
     cli_state_t state;
     cli_state_t next_state[CLI_TERM+1];
+    int rank;
+    char *ns;
 } cli_info_t;
 
 extern cli_info_t *cli_info;

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -32,6 +32,7 @@
 #include "src/class/pmix_object.h"
 #include "src/buffer_ops/types.h"
 #include "test_common.h"
+#include "test_fence.h"
 
 static int get_local_peers(int **_peers, int *count)
 {
@@ -184,6 +185,10 @@ int main(int argc, char **argv)
     }
 
     TEST_VERBOSE(("rank %d: Universe size check: PASSED", rank));
+
+    if (NULL != params.fences) {
+        test_fence(params, -1, rank);
+    }
 
     if( NULL != params.nspace && 0 != strcmp(nspace, params.nspace) ) {
         TEST_ERROR(("rank %d: Bad nspace!", rank));

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -37,17 +37,10 @@ int main(int argc, char **argv)
     char **client_env=NULL;
     char **client_argv=NULL;
     int rc;
-    uint32_t n;
-    char *tmp;
-    uid_t myuid;
-    gid_t mygid;
     struct stat stat_buf;
     struct timeval tv;
     double test_start;
-    char *ranks = NULL;
     int order[CLI_TERM+1];
-    char digit[MAX_DIGIT_LEN];
-    int cl_arg_len;
     test_params params;
     INIT_TEST_PARAMS(params);
     int test_fail = 0;
@@ -90,29 +83,6 @@ int main(int argc, char **argv)
     /* register the errhandler */
     PMIx_Register_errhandler(errhandler);
 
-    TEST_VERBOSE(("Setting job info"));
-    fill_seq_ranks_array(params.nprocs, &ranks);
-    if (NULL == ranks) {
-        PMIx_server_finalize();
-        TEST_ERROR(("fill_seq_ranks_array failed"));
-        FREE_TEST_PARAMS(params);
-        return PMIX_ERROR;
-    }
-    set_namespace(params.nprocs, ranks, TEST_NAMESPACE);
-    if (NULL != ranks) {
-        free(ranks);
-    }
-
-    /* fork/exec the test */
-    client_env = pmix_argv_copy(environ);
-    set_client_argv(&params, &client_argv);
-    tmp = pmix_argv_join(client_argv, ' ');
-    TEST_VERBOSE(("Executing test: %s", tmp));
-    free(tmp);
-
-    myuid = getuid();
-    mygid = getgid();
-
     order[CLI_UNINIT] = CLI_FORKED;
     order[CLI_FORKED] = CLI_FIN;
     order[CLI_CONNECTED] = -1;
@@ -121,51 +91,10 @@ int main(int argc, char **argv)
     order[CLI_TERM] = -1;
     cli_init(params.nprocs, order);
 
-    for (n=0; n < params.nprocs; n++) {
-        if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(TEST_NAMESPACE, n, &client_env))) {
-            TEST_ERROR(("Server fork setup failed with error %d", rc));
-            PMIx_server_finalize();
-            cli_kill_all();
-            FREE_TEST_PARAMS(params);
-            return rc;
-        }
-        if (PMIX_SUCCESS != (rc = PMIx_server_register_client(TEST_NAMESPACE, n, myuid, mygid, NULL))) {
-            TEST_ERROR(("Server fork setup failed with error %d", rc));
-            PMIx_server_finalize();
-            cli_kill_all();
-            FREE_TEST_PARAMS(params);
-            return rc;
-        }
-
-        cli_info[n].pid = fork();
-        if (cli_info[n].pid < 0) {
-            TEST_ERROR(("Fork failed"));
-            PMIx_server_finalize();
-            cli_kill_all();
-            FREE_TEST_PARAMS(params);
-            return -1;
-        }
-        /* add two last arguments: -r <rank> */
-        sprintf(digit, "%d", n);
-        pmix_argv_append_nosize(&client_argv, "-r");
-        pmix_argv_append_nosize(&client_argv, digit);
-
-        if (cli_info[n].pid == 0) {
-            if( !TEST_VERBOSE_GET() ){
-                // Hide clients stdout
-                // TODO: on some systems stdout is a constant, address this
-                fclose(stdout);
-                stdout = fopen("/dev/null","w");
-            }
-            execve(params.binary, client_argv, client_env);
-            /* Does not return */
-            exit(0);
-        }
-        cli_info[n].state = CLI_FORKED;
-
-        /* delete two last arguments : -r <rank> */
-        cl_arg_len = pmix_argv_len(client_argv);
-        pmix_argv_delete(&cl_arg_len, &client_argv, cl_arg_len-2, 2);
+    /* set namespaces and fork clients */
+    rc = launch_clients(params, &client_env, &client_argv);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
     }
 
     /* hang around until the client(s) finalize */

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -26,7 +26,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include "src/util/argv.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/output.h"
 
@@ -106,35 +105,7 @@ int main(int argc, char **argv)
 
     /* fork/exec the test */
     client_env = pmix_argv_copy(environ);
-    pmix_argv_append_nosize(&client_argv, params.binary);
-    pmix_argv_append_nosize(&client_argv, "-s");
-    pmix_argv_append_nosize(&client_argv, TEST_NAMESPACE);
-    if (params.nonblocking) {
-        pmix_argv_append_nosize(&client_argv, "-nb");
-        if (params.barrier) {
-            pmix_argv_append_nosize(&client_argv, "-b");
-        }
-    }
-    if (params.collect) {
-        pmix_argv_append_nosize(&client_argv, "-c");
-    }
-    pmix_argv_append_nosize(&client_argv, "-n");
-    if (NULL == params.np) {
-        pmix_argv_append_nosize(&client_argv, "1");
-    } else {
-        pmix_argv_append_nosize(&client_argv, params.np);
-    }
-    if( params.verbose ){
-        pmix_argv_append_nosize(&client_argv, "-v");
-    }
-    if (NULL != params.prefix) {
-        pmix_argv_append_nosize(&client_argv, "-o");
-        pmix_argv_append_nosize(&client_argv, params.prefix);
-    }
-    if( params.early_fail ){
-        pmix_argv_append_nosize(&client_argv, "--early-fail");
-    }
-
+    set_client_argv(&params, &client_argv);
     tmp = pmix_argv_join(client_argv, ' ');
     TEST_VERBOSE(("Executing test: %s", tmp));
     free(tmp);

--- a/test/pmix_test_lite.c
+++ b/test/pmix_test_lite.c
@@ -25,7 +25,6 @@
  */
 
 #include <stdio.h>
-#include "src/util/pmix_environ.h"
 #include "src/util/output.h"
 
 #include "server_callbacks.h"
@@ -44,18 +43,11 @@ int main(int argc, char **argv)
     char **client_env=NULL;
     char **client_argv=NULL;
     int rc;
-    uint32_t n;
-    char *tmp;
-    uid_t myuid;
-    gid_t mygid;
     struct sockaddr_un address;
     struct stat stat_buf;
     struct timeval tv;
     double test_start;
-    char *ranks = NULL;
     int order[CLI_TERM+1];
-    char digit[MAX_DIGIT_LEN];
-    int cl_arg_len;
     test_params params;
     INIT_TEST_PARAMS(params);
     int test_fail = 0;
@@ -96,18 +88,13 @@ int main(int argc, char **argv)
     /* register the errhandler */
     PMIx_Register_errhandler(errhandler);
 
-    TEST_VERBOSE(("Setting job info"));
-    fill_seq_ranks_array(params.nprocs, &ranks);
-    if (NULL == ranks) {
-        PMIx_server_finalize();
-        TEST_ERROR(("fill_seq_ranks_array failed"));
-        FREE_TEST_PARAMS(params);
-        return PMIX_ERROR;
-    }
-    set_namespace(params.nprocs, ranks, TEST_NAMESPACE);
-    if (NULL != ranks) {
-        free(ranks);
-    }
+    order[CLI_UNINIT] = CLI_FORKED;
+    order[CLI_FORKED] = CLI_CONNECTED;
+    order[CLI_CONNECTED] = CLI_FIN;
+    order[CLI_FIN] = CLI_DISCONN;
+    order[CLI_DISCONN] = CLI_TERM;
+    order[CLI_TERM] = -1;
+    cli_init(params.nprocs, order);
 
     /* initialize the event library - we will be providing messaging support
      * for the server */
@@ -131,75 +118,10 @@ int main(int argc, char **argv)
         exit(0);
     }
 
-    client_env = pmix_argv_copy(environ);
-    set_client_argv(&params, &client_argv);
-
-    tmp = pmix_argv_join(client_argv, ' ');
-    TEST_VERBOSE(("Executing test: %s", tmp));
-    free(tmp);
-
-    myuid = getuid();
-    mygid = getgid();
-
-    order[CLI_UNINIT] = CLI_FORKED;
-    order[CLI_FORKED] = CLI_CONNECTED;
-    order[CLI_CONNECTED] = CLI_FIN;
-    order[CLI_FIN] = CLI_DISCONN;
-    order[CLI_DISCONN] = CLI_TERM;
-    order[CLI_TERM] = -1;
-    cli_init(params.nprocs, order);
-
-    /* fork/exec the test */
-    for (n=0; n < params.nprocs; n++) {
-        if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(TEST_NAMESPACE, n, &client_env))) {
-            TEST_ERROR(("Server fork setup failed with error %d", rc));
-            PMIx_server_finalize();
-            cli_kill_all();
-            FREE_TEST_PARAMS(params);
-            return rc;
-        }
-        if (PMIX_SUCCESS != (rc = PMIx_server_register_client(TEST_NAMESPACE, n, myuid, mygid, NULL))) {
-            TEST_ERROR(("Server fork setup failed with error %d", rc));
-            PMIx_server_finalize();
-            cli_kill_all();
-            FREE_TEST_PARAMS(params);
-            return rc;
-        }
-
-//        for (i=0; NULL != client_env[i]; i++) {
-//            TEST_VERBOSE(("env[%d]: %s", i, client_env[i]));
-//        }
-
-        cli_info[n].pid = fork();
-        if (cli_info[n].pid < 0) {
-            TEST_ERROR(("Fork failed"));
-            PMIx_server_finalize();
-            cli_kill_all();
-            FREE_TEST_PARAMS(params);
-            return -1;
-        }
-
-        /* add two last arguments: -r <rank> */
-        sprintf(digit, "%d", n);
-        pmix_argv_append_nosize(&client_argv, "-r");
-        pmix_argv_append_nosize(&client_argv, digit);
-
-        if (cli_info[n].pid == 0) {
-            if( !TEST_VERBOSE_GET() ){
-                // Hide clients stdout
-                // TODO: on some systems stdout is a constant, address this
-                fclose(stdout);
-                stdout = fopen("/dev/null","w");
-            }
-            execve(params.binary, client_argv, client_env);
-            /* Does not return */
-            exit(0);
-        }
-        cli_info[n].state = CLI_FORKED;
-
-        /* delete two last arguments : -r <rank> */
-        cl_arg_len = pmix_argv_len(client_argv);
-        pmix_argv_delete(&cl_arg_len, &client_argv, cl_arg_len-2, 2);
+    /* set namespaces and fork clients */
+    rc = launch_clients(params, &client_env, &client_argv);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
     }
 
     /* hang around until the client(s) finalize */

--- a/test/pmix_test_lite.c
+++ b/test/pmix_test_lite.c
@@ -25,7 +25,6 @@
  */
 
 #include <stdio.h>
-#include "src/util/argv.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/output.h"
 
@@ -133,36 +132,7 @@ int main(int argc, char **argv)
     }
 
     client_env = pmix_argv_copy(environ);
-
-    /* fork/exec the test */
-    pmix_argv_append_nosize(&client_argv, params.binary);
-    pmix_argv_append_nosize(&client_argv, "-s");
-    pmix_argv_append_nosize(&client_argv, TEST_NAMESPACE);
-    if (params.nonblocking) {
-        pmix_argv_append_nosize(&client_argv, "-nb");
-        if (params.barrier) {
-            pmix_argv_append_nosize(&client_argv, "-b");
-        }
-    }
-    if (params.collect) {
-        pmix_argv_append_nosize(&client_argv, "-c");
-    }
-    pmix_argv_append_nosize(&client_argv, "-n");
-    if (NULL == params.np) {
-        pmix_argv_append_nosize(&client_argv, "1");
-    } else {
-        pmix_argv_append_nosize(&client_argv, params.np);
-    }
-    if( params.verbose ){
-        pmix_argv_append_nosize(&client_argv, "-v");
-    }
-    if (NULL != params.prefix) {
-        pmix_argv_append_nosize(&client_argv, "-o");
-        pmix_argv_append_nosize(&client_argv, params.prefix);
-    }
-    if( params.early_fail ){
-        pmix_argv_append_nosize(&client_argv, "--early-fail");
-    }
+    set_client_argv(&params, &client_argv);
 
     tmp = pmix_argv_join(client_argv, ' ');
     TEST_VERBOSE(("Executing test: %s", tmp));
@@ -179,6 +149,7 @@ int main(int argc, char **argv)
     order[CLI_TERM] = -1;
     cli_init(params.nprocs, order);
 
+    /* fork/exec the test */
     for (n=0; n < params.nprocs; n++) {
         if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(TEST_NAMESPACE, n, &client_env))) {
             TEST_ERROR(("Server fork setup failed with error %d", rc));

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -87,6 +87,21 @@ void parse_cmd(int argc, char **argv, test_params *params)
             }
         } else if( 0 == strcmp(argv[i], "--early-fail") ){
             params->early_fail = 1;
+        } else if (0 == strcmp(argv[i], "--fence")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->fences = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--data")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->data = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--noise")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->noise = strdup(argv[i]);
+            }
         }
 
         else {

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -33,6 +33,9 @@ void parse_cmd(int argc, char **argv, test_params *params)
             if (NULL != argv[i]) {
                 params->np = strdup(argv[i]);
                 params->nprocs = strtol(argv[i], NULL, 10);
+                if (-1 == params->ns_size) {
+                    params->ns_size = params->nprocs;
+                }
             }
         } else if (0 == strcmp(argv[i], "--h") || 0 == strcmp(argv[i], "-h")) {
             /* print help */
@@ -105,6 +108,26 @@ void parse_cmd(int argc, char **argv, test_params *params)
             i++;
             if (NULL != argv[i]) {
                 params->noise = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--ns-dist")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->ns_dist = strdup(argv[i]);
+            }
+        } else if (0 == strcmp(argv[i], "--ns-size")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->ns_size = strtol(argv[i], NULL, 10);
+            }
+        } else if (0 == strcmp(argv[i], "--ns-id")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->ns_id = strtol(argv[i], NULL, 10);
+            }
+        } else if (0 == strcmp(argv[i], "--base-rank")) {
+            i++;
+            if (NULL != argv[i]) {
+                params->base_rank = strtol(argv[i], NULL, 10);
             }
         }
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -65,9 +65,9 @@ extern FILE *file;
 #define TEST_DEFAULT_TIMEOUT 10
 #define MAX_DIGIT_LEN 10
 
-#define TEST_SET_FILE(prefix, rank) { \
+#define TEST_SET_FILE(prefix, ns_id, rank) { \
     char *fname = malloc( strlen(prefix) + MAX_DIGIT_LEN + 2 ); \
-    sprintf(fname, "%s.%d", prefix, rank); \
+    sprintf(fname, "%s.%d.%d", prefix, ns_id, rank); \
     file = fopen(fname, "w"); \
     free(fname); \
     if( NULL == file ){ \
@@ -98,6 +98,10 @@ typedef struct {
     char *fences;
     char *data;
     char *noise;
+    char *ns_dist;
+    int ns_size;
+    int ns_id;
+    int base_rank;
 } test_params;
 
 #define INIT_TEST_PARAMS(params) do { \
@@ -108,14 +112,17 @@ typedef struct {
     params.verbose = 0;               \
     params.rank = 0;                  \
     params.early_fail = 0;            \
+    params.ns_size = -1;              \
+    params.ns_id = -1;                \
+    params.timeout = TEST_DEFAULT_TIMEOUT; \
     params.binary = NULL;             \
     params.np = NULL;                 \
-    params.timeout = TEST_DEFAULT_TIMEOUT; \
     params.prefix = NULL;             \
     params.nspace = NULL;             \
     params.fences = NULL;             \
     params.data = NULL;               \
     params.noise = NULL;              \
+    params.ns_dist = NULL;            \
 } while (0)
 
 #define FREE_TEST_PARAMS(params) do { \
@@ -139,6 +146,9 @@ typedef struct {
     }                                 \
     if (NULL != params.noise) {       \
         free(params.noise);           \
+    }                                 \
+    if (NULL != params.ns_dist) {     \
+        free(params.ns_dist);         \
     }                                 \
 } while (0)
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -93,6 +93,9 @@ typedef struct {
     int verbose;
     int rank;
     int early_fail;
+    char *fences;
+    char *data;
+    char *noise;
 } test_params;
 
 #define INIT_TEST_PARAMS(params) do { \
@@ -108,6 +111,9 @@ typedef struct {
     params.timeout = TEST_DEFAULT_TIMEOUT; \
     params.prefix = NULL;             \
     params.nspace = NULL;             \
+    params.fences = NULL;             \
+    params.data = NULL;               \
+    params.noise = NULL;              \
 } while (0)
 
 #define FREE_TEST_PARAMS(params) do { \
@@ -122,6 +128,15 @@ typedef struct {
     }                                 \
     if (NULL != params.nspace) {      \
         free(params.nspace);          \
+    }                                 \
+    if (NULL != params.fences) {      \
+        free(params.fences);          \
+    }                                 \
+    if (NULL != params.data) {        \
+        free(params.data);            \
+    }                                 \
+    if (NULL != params.noise) {       \
+        free(params.noise);           \
     }                                 \
 } while (0)
 

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -19,6 +19,8 @@
 #include <unistd.h>
 #include <stdint.h>
 
+#include "src/class/pmix_list.h"
+
 #define TEST_NAMESPACE "smoky_nspace"
 #define TEST_CREDENTIAL "dummy"
 
@@ -141,5 +143,29 @@ typedef struct {
 } while (0)
 
 void parse_cmd(int argc, char **argv, test_params *params);
+int parse_fence(char *fence_param, int store);
+
+typedef struct {
+    pmix_list_item_t super;
+    int rank;
+} rank_desc_t;
+PMIX_CLASS_DECLARATION(rank_desc_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    int id;
+    pmix_list_t ranks;
+} nspace_desc_t;
+PMIX_CLASS_DECLARATION(nspace_desc_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    int blocking;
+    int data_exchange;
+    pmix_list_t nspaces;
+} fence_desc_t;
+PMIX_CLASS_DECLARATION(fence_desc_t);
+
+extern pmix_list_t test_fences;
 
 #endif // TEST_COMMON_H

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -1,0 +1,26 @@
+#include "test_fence.h"
+
+int test_fence(test_params params, int my_nspace, int my_rank)
+{
+    int i = 0;
+    int len;
+    fence_desc_t *desc;
+    nspace_desc_t *ndesc;
+    rank_desc_t *rdesc;
+    PMIX_CONSTRUCT(&test_fences, pmix_list_t);
+    parse_fence(params.fences, 1);
+    PMIX_LIST_FOREACH(desc, &test_fences, fence_desc_t) {
+        char tmp[256] = {0};
+        len = sprintf(tmp, "fence %d: block = %d de = %d ", i, desc->blocking, desc->data_exchange);
+        i++;
+        PMIX_LIST_FOREACH(ndesc, &(desc->nspaces), nspace_desc_t) {
+            len += sprintf(tmp+len, "ns %d ranks: ", ndesc->id);
+            PMIX_LIST_FOREACH(rdesc, &(ndesc->ranks), rank_desc_t) {
+                len += sprintf(tmp+len, "%d,", rdesc->rank);
+            }
+        }
+        fprintf(stderr,"tmp = %s\n",  tmp);
+    }
+    PMIX_LIST_DESTRUCT(&test_fences);
+    return 0;
+}

--- a/test/test_fence.h
+++ b/test/test_fence.h
@@ -1,0 +1,3 @@
+#include "test_common.h"
+
+int test_fence(test_params params, int my_nspace, int my_rank);

--- a/test/utils.c
+++ b/test/utils.c
@@ -47,3 +47,47 @@ void set_namespace(int nprocs, char *ranks, char *name)
     PMIX_INFO_FREE(info, ninfo);
 }
 
+void set_client_argv(test_params *params, char ***argv)
+{
+    pmix_argv_append_nosize(argv, params->binary);
+    pmix_argv_append_nosize(argv, "-s");
+    pmix_argv_append_nosize(argv, TEST_NAMESPACE);
+    if (params->nonblocking) {
+        pmix_argv_append_nosize(argv, "-nb");
+        if (params->barrier) {
+            pmix_argv_append_nosize(argv, "-b");
+        }
+    }
+    if (params->collect) {
+        pmix_argv_append_nosize(argv, "-c");
+    }
+    pmix_argv_append_nosize(argv, "-n");
+    if (NULL == params->np) {
+        pmix_argv_append_nosize(argv, "1");
+    } else {
+        pmix_argv_append_nosize(argv, params->np);
+    }
+    if( params->verbose ){
+        pmix_argv_append_nosize(argv, "-v");
+    }
+    if (NULL != params->prefix) {
+        pmix_argv_append_nosize(argv, "-o");
+        pmix_argv_append_nosize(argv, params->prefix);
+    }
+    if( params->early_fail ){
+        pmix_argv_append_nosize(argv, "--early-fail");
+    }
+    if (NULL != params->fences) {
+        pmix_argv_append_nosize(argv, "--fence");
+        pmix_argv_append_nosize(argv, params->fences);
+    }
+    if (NULL != params->data) {
+        pmix_argv_append_nosize(argv, "--data");
+        pmix_argv_append_nosize(argv, params->data);
+    }
+    if (NULL != params->noise) {
+        pmix_argv_append_nosize(argv, "--noise");
+        pmix_argv_append_nosize(argv, params->noise);
+    }
+
+}

--- a/test/utils.h
+++ b/test/utils.h
@@ -3,7 +3,10 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdint.h>
+#include "src/util/argv.h"
+#include "test_common.h"
 
 void fill_seq_ranks_array(size_t nprocs, char **ranks);
 void set_namespace(int nprocs, char *ranks, char *name);
+void set_client_argv(test_params *params, char ***argv);
 

--- a/test/utils.h
+++ b/test/utils.h
@@ -6,7 +6,4 @@
 #include "src/util/argv.h"
 #include "test_common.h"
 
-void fill_seq_ranks_array(size_t nprocs, char **ranks);
-void set_namespace(int nprocs, char *ranks, char *name);
-void set_client_argv(test_params *params, char ***argv);
-
+int launch_clients(test_params params, char *** client_env, char ***client_argv);

--- a/test/utils.h
+++ b/test/utils.h
@@ -6,4 +6,5 @@
 #include "src/util/argv.h"
 #include "test_common.h"
 
-int launch_clients(test_params params, char *** client_env, char ***client_argv);
+void set_client_argv(test_params *params, char ***argv);
+int launch_clients(int num_procs, char *binary, char *** client_env, char ***client_argv);


### PR DESCRIPTION
1. Added --fence cmd line option to specify multiple fences with different configurations in parsable format. Example: [db | 1:1,2 ; 2:3-6][1: ]  means that need to test two fences. The first one is blocking (b) and with data exchange (d) including ranks 1,2 from namespace 1 and ranks 3-6 from namespace 2. The second fence is non-blocking without data exchange including all processes from namespace 1.

2. Added --ns-dist cmd line option to associate clients with different namespaces: 
1:2:8 means to run 1 process in ns-0, 2 processes in ns-2, 8 processes in ns-8. 
The thing is that in current tests we have just a single server process and register multiple namespaces by it. It affects lite server version so that we don't know namespace during authentication. That's why I set ranks in series across all namespaces and transfer base_rank to each client (base rank is the smallest rank in that process's namespace) to handle following fence/get operations.