### PR TITLE
Test for different fence configurations.

### DIFF
--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -185,7 +185,11 @@ int main(int argc, char **argv)
     TEST_VERBOSE(("rank %d: Universe size check: PASSED", rank));
 
     if (NULL != params.fences) {
-        test_fence(params, -1, rank);
+        rc = test_fence(params, params.nspace, rank);
+        if (PMIX_SUCCESS != rc) {
+            FREE_TEST_PARAMS(params);
+            exit(0);
+        }
     }
 
     if( NULL != params.nspace && 0 != strcmp(nspace, params.nspace) ) {

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -41,7 +41,6 @@ void parse_cmd(int argc, char **argv, test_params *params)
             /* print help */
             fprintf(stderr, "usage: pmix_test [-h] [-e foo] [-b] [-c] [-nb]\n");
             fprintf(stderr, "\t-n       provides information about the job size (for checking purposes)\n");
-            fprintf(stderr, "\t-s nsp   namespace of the job (for checking purposes)\n");
             fprintf(stderr, "\t-e foo   use foo as test client\n");
             fprintf(stderr, "\t-b       execute fence_nb callback when all procs reach that point\n");
             fprintf(stderr, "\t-c       fence[_nb] callback shall include all collected data\n");

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -49,6 +49,9 @@ void parse_cmd(int argc, char **argv, test_params *params)
             fprintf(stderr, "\t-t <>    set timeout\n");
             fprintf(stderr, "\t-o out   redirect clients logs to file out.<rank>\n");
             fprintf(stderr, "\t--early-fail    force client process with rank 0 to fail before PMIX_Init.\n");
+            fprintf(stderr, "\t--ns-dist n1:n2:n3   register n namespaces (3 in this example) each with ni ranks (n1, n2 or n3).\n");
+            fprintf(stderr, "\t--fence \"[<data_exchange><blocking> | ns0:ranks;ns1:ranks...][...]\"  specify fences in different configurations.\n");
+            fprintf(stderr, "\t--noise \"[ns0:ranks;ns1:ranks...]\"  add system noise to specified processes.\n");
             exit(0);
         } else if (0 == strcmp(argv[i], "--exec") || 0 == strcmp(argv[i], "-e")) {
             i++;
@@ -107,6 +110,10 @@ void parse_cmd(int argc, char **argv, test_params *params)
             i++;
             if (NULL != argv[i]) {
                 params->noise = strdup(argv[i]);
+                if (0 != parse_noise(params->noise, 0)) {
+                    fprintf(stderr, "Incorrect --noise option format: %s\n", params->noise);
+                    exit(1);
+                }
             }
         } else if (0 == strcmp(argv[i], "--ns-dist")) {
             i++;
@@ -141,6 +148,7 @@ void parse_cmd(int argc, char **argv, test_params *params)
 }
 
 pmix_list_t test_fences;
+range_desc_t *noise_range = NULL;
 
 static void ncon(nspace_desc_t *p)
 {
@@ -161,12 +169,12 @@ static void fcon(fence_desc_t *p)
 {
     p->blocking = 0;
     p->data_exchange = 0;
-    PMIX_CONSTRUCT(&(p->nspaces), pmix_list_t);
+    p->range = PMIX_NEW(range_desc_t);
 }
 
 static void fdes(fence_desc_t *p)
 {
-    PMIX_LIST_DESTRUCT(&(p->nspaces));
+    PMIX_RELEASE(p->range);
 }
 
 PMIX_CLASS_INSTANCE(fence_desc_t,
@@ -177,8 +185,23 @@ PMIX_CLASS_INSTANCE(rank_desc_t,
                           pmix_list_item_t,
                           NULL, NULL);
 
+static void rcon(range_desc_t *p)
+{
+    PMIX_CONSTRUCT(&(p->nspaces), pmix_list_t);
+}
+
+static void rdes(range_desc_t *p)
+{
+    PMIX_LIST_DESTRUCT(&(p->nspaces));
+}
+
+PMIX_CLASS_INSTANCE(range_desc_t,
+                          pmix_list_item_t,
+                          rcon, rdes);
+
 static int ns_id = -1;
 static fence_desc_t *fdesc = NULL;
+static range_desc_t *range = NULL;
 
 #define CHECK_STRTOL_VAL(val, str, store) do {                  \
     if (0 == val) {                                             \
@@ -203,6 +226,7 @@ static int parse_token(char *str, int step, int store)
         case 0:
             if (store) {
                 fdesc = PMIX_NEW(fence_desc_t);
+                range = fdesc->range;
             }
             pch = strchr(str, '|');
             if (NULL != pch) {
@@ -239,6 +263,10 @@ static int parse_token(char *str, int step, int store)
             }
             break;
         case 1:
+            if (store && NULL == range) {
+                range = PMIX_NEW(range_desc_t);
+                noise_range = range;
+            }
             pch = strtok(str, ";");
             while (NULL != pch) {
                 if (0 < parse_token(pch, 2, store)) {
@@ -254,6 +282,9 @@ static int parse_token(char *str, int step, int store)
             if (NULL != pch) {
                 *pch = '\0';
                 pch++;
+                while (' ' == *str) {
+                    str++;
+                }
                 ns_id = (int)(strtol(str, NULL, 10));
                 CHECK_STRTOL_VAL(ns_id, str, store);
                 if (0 < parse_token(pch, 3, store)) {
@@ -268,13 +299,16 @@ static int parse_token(char *str, int step, int store)
             }
             break;
         case 3:
-            if (store && NULL != fdesc) {
+            if (store && NULL != range) {
                 ndesc = PMIX_NEW(nspace_desc_t);
                 ndesc->id = ns_id;
             }
+            while (' ' == *str) {
+                str++;
+            }
             if ('\0' == *str) {
                 /* all ranks from namespace participate */
-                if (store && NULL != fdesc) {
+                if (store && NULL != range) {
                     rdesc = PMIX_NEW(rank_desc_t);
                     rdesc->rank = -1;
                     pmix_list_append(&(ndesc->ranks), &rdesc->super);
@@ -287,7 +321,7 @@ static int parse_token(char *str, int step, int store)
                         rank = (int)(strtol(str-count, NULL, 10));
                         CHECK_STRTOL_VAL(rank, str-count, store);
                         for (i = remember; i < rank; i++) {
-                            if (store && NULL != fdesc) {
+                            if (store && NULL != range) {
                                 rdesc = PMIX_NEW(rank_desc_t);
                                 rdesc->rank = i;
                                 pmix_list_append(&(ndesc->ranks), &rdesc->super);
@@ -297,7 +331,7 @@ static int parse_token(char *str, int step, int store)
                     }
                     rank = (int)(strtol(str-count, NULL, 10));
                     CHECK_STRTOL_VAL(rank, str-count, store);
-                    if (store && NULL != fdesc) {
+                    if (store && NULL != range) {
                         rdesc = PMIX_NEW(rank_desc_t);
                         rdesc->rank = rank;
                         pmix_list_append(&(ndesc->ranks), &rdesc->super);
@@ -317,7 +351,7 @@ static int parse_token(char *str, int step, int store)
                     rank = (int)(strtol(str-count, NULL, 10));
                     CHECK_STRTOL_VAL(rank, str-count, store);
                     for (i = remember; i < rank; i++) {
-                        if (store && NULL != fdesc) {
+                        if (store && NULL != range) {
                             rdesc = PMIX_NEW(rank_desc_t);
                             rdesc->rank = i;
                             pmix_list_append(&(ndesc->ranks), &rdesc->super);
@@ -327,14 +361,14 @@ static int parse_token(char *str, int step, int store)
                 }
                 rank = (int)(strtol(str-count, NULL, 10));
                 CHECK_STRTOL_VAL(rank, str-count, store);
-                if (store && NULL != fdesc) {
+                if (store && NULL != range) {
                     rdesc = PMIX_NEW(rank_desc_t);
                     rdesc->rank = rank;
                     pmix_list_append(&(ndesc->ranks), &rdesc->super);
                 }
             }
-            if (store && NULL != fdesc) {
-                pmix_list_append(&(fdesc->nspaces), &ndesc->super);
+            if (store && NULL != range) {
+                pmix_list_append(&(range->nspaces), &ndesc->super);
             }
             break;
         default:
@@ -349,6 +383,7 @@ int parse_fence(char *fence_param, int store)
     int ret = 0;
     char *tmp = strdup(fence_param);
     char * pch, *ech;
+    range = NULL;
     pch = strchr(tmp, '[');
     while (NULL != pch) {
         pch++;
@@ -361,6 +396,32 @@ int parse_fence(char *fence_param, int store)
         } else {
             ret = 1;
             break;
+        }
+    }
+    free(tmp);
+    return ret;
+}
+
+int parse_noise(char *noise_param, int store)
+{
+    int ret = 0;
+    char *tmp = strdup(noise_param);
+    char * pch, *ech;
+    range = NULL;
+    pch = strchr(tmp, '[');
+    if (NULL != pch) {
+        pch++;
+        ech = strchr(pch, ']');
+        if (NULL != ech) {
+            *ech = '\0';
+            ech++;
+            if ('\0' != *ech) {
+                ret = 1;
+            } else {
+                ret = parse_token(pch, 1, store);
+            }
+        } else {
+            ret = 1;
         }
     }
     free(tmp);

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -154,6 +154,7 @@ typedef struct {
 
 void parse_cmd(int argc, char **argv, test_params *params);
 int parse_fence(char *fence_param, int store);
+int parse_noise(char *noise_param, int store);
 
 typedef struct {
     pmix_list_item_t super;
@@ -170,12 +171,19 @@ PMIX_CLASS_DECLARATION(nspace_desc_t);
 
 typedef struct {
     pmix_list_item_t super;
+    pmix_list_t nspaces;
+} range_desc_t;
+PMIX_CLASS_DECLARATION(range_desc_t);
+
+typedef struct {
+    pmix_list_item_t super;
     int blocking;
     int data_exchange;
-    pmix_list_t nspaces;
+    range_desc_t *range;
 } fence_desc_t;
 PMIX_CLASS_DECLARATION(fence_desc_t);
 
 extern pmix_list_t test_fences;
+extern range_desc_t *noise_range;
 
 #endif // TEST_COMMON_H

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -1,26 +1,179 @@
 #include "test_fence.h"
 
-int test_fence(test_params params, int my_nspace, int my_rank)
+static void release_cb(pmix_status_t status, void *cbdata)
 {
-    int i = 0;
+    int *ptr = (int*)cbdata;
+    *ptr = 0;
+}
+
+int test_fence(test_params params, char *my_nspace, int my_rank)
+{
     int len;
+    int rc;
+    size_t i, j;
     fence_desc_t *desc;
     nspace_desc_t *ndesc;
     rank_desc_t *rdesc;
+    size_t nranges;
+    pmix_range_t *rngs;
+    int n = 0, r = 0;
+    int participate = 0;
+    int fence_num = 0;
+    pmix_value_t value;
+    char key[50], sval[50];
+    pmix_value_t *val = &value;
+
     PMIX_CONSTRUCT(&test_fences, pmix_list_t);
     parse_fence(params.fences, 1);
+
     PMIX_LIST_FOREACH(desc, &test_fences, fence_desc_t) {
+        nranges = pmix_list_get_size(&(desc->nspaces));
+        PMIX_RANGE_CREATE(rngs, nranges);
         char tmp[256] = {0};
-        len = sprintf(tmp, "fence %d: block = %d de = %d ", i, desc->blocking, desc->data_exchange);
-        i++;
+        len = sprintf(tmp, "fence %d: block = %d de = %d ", fence_num, desc->blocking, desc->data_exchange);
+        n = 0;
         PMIX_LIST_FOREACH(ndesc, &(desc->nspaces), nspace_desc_t) {
+            (void)snprintf(rngs[n].nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ndesc->id);
+            rngs[n].nranks = pmix_list_get_size(&(ndesc->ranks));
+            if (0 < rngs[n].nranks) {
+                rngs[n].ranks = (int*)malloc(rngs[n].nranks * sizeof(int));
+            }
             len += sprintf(tmp+len, "ns %d ranks: ", ndesc->id);
+            r = 0;
             PMIX_LIST_FOREACH(rdesc, &(ndesc->ranks), rank_desc_t) {
-                len += sprintf(tmp+len, "%d,", rdesc->rank);
+                if (!strncmp(my_nspace, rngs[n].nspace, strlen(my_nspace)) && (my_rank == rdesc->rank || -1 == rdesc->rank)) {
+                    participate = 1;
+                }
+                if (-1 == rdesc->rank) {
+                    len += sprintf(tmp+len, "all; ");
+                    free(rngs[n].ranks);
+                    rngs[n].ranks = NULL;
+                    rngs[n].nranks = 0;
+                    break;
+                } else {
+                    len += sprintf(tmp+len, "%d,", rdesc->rank);
+                    rngs[n].ranks[r] = rdesc->rank;
+                }
+                r++;
+            }
+            n++;
+        }
+        fprintf(stderr,"tmp = %s,  me: %s:%d participate = %d\n",  tmp, my_nspace, my_rank, participate);
+        if (1 == participate) {
+            /*run fence test on this range */
+            /* first put value (my_ns, my_rank) with key based on fence_num to split results of different fences*/
+            (void)snprintf(key, 50, "key-f%d", fence_num);
+            (void)snprintf(sval, 50, "%s:%d", my_nspace, my_rank);
+            fprintf(stderr, "%s:%d put key %s val %s\n", my_nspace, my_rank, key, sval);
+            PMIX_VAL_SET(&value, string, sval);
+            if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
+                TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
+            }
+            PMIX_VALUE_DESTRUCT(&value);
+
+            /* Submit the data */
+            if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+                TEST_ERROR(("%s:%d: PMIx_Commit failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
+            }
+
+            /* perform fence */
+            if( desc->blocking ){
+                if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, desc->data_exchange))) {
+                    TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+                    PMIX_RANGE_FREE(rngs, nranges);
+                    PMIX_LIST_DESTRUCT(&test_fences);
+                    return rc;
+                }
+            } else {
+                int in_progress = 1, count;
+                if ( PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, desc->data_exchange, release_cb, &in_progress))) {
+                    TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+                    PMIX_RANGE_FREE(rngs, nranges);
+                    PMIX_LIST_DESTRUCT(&test_fences);
+                    return rc;
+                }
+
+                count = 0;
+                while( in_progress ){
+                    struct timespec ts;
+                    ts.tv_sec = 0;
+                    ts.tv_nsec = 100;
+                    nanosleep(&ts,NULL);
+                    count++;
+                }
+                TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs", count*100*1E-9));
+            }
+            TEST_VERBOSE(("%s:%d: Fence successfully completed", my_nspace, my_rank));
+
+            /* get data from all participating in this fence clients */
+            for (i = 0; i < nranges; i++ ) {
+                /* handle case if all processes from the namespace should participate (ranks == NULL):
+                 * parse --ns-dist option and count number of processes and rank offset for the target namespace
+                 * to fill ranks array in the current range. This needs to be done for checking purposes.*/
+                if (0 == rngs[i].nranks && NULL == rngs[i].ranks) {
+                    int base_rank = 0;
+                    size_t num_ranks = 0;
+                    int num = -1;
+                    if (NULL == params.ns_dist) {
+                        rngs[i].nranks = params.ns_size;
+                        rngs[i].ranks = (int*)malloc(params.ns_size * sizeof(int));
+                        for (j = 0; j < (size_t)params.ns_size; j++) {
+                            rngs[i].ranks[j] = j;
+                        }
+                    } else {
+                        char *pch = params.ns_dist;
+                        int ns_id = (int)strtol(rngs[i].nspace + strlen(TEST_NAMESPACE) + 1, NULL, 10);
+                        while (NULL != pch && num != ns_id) {
+                            base_rank += num_ranks;
+                            pch = strtok((-1 == num ) ? params.ns_dist : NULL, ":");
+                            num++;
+                            num_ranks = (size_t)strtol(pch, NULL, 10);
+                        }
+                        if (num == ns_id && 0 != num_ranks) {
+                            rngs[i].nranks = num_ranks;
+                            rngs[i].ranks = (int*)malloc(num_ranks * sizeof(int));
+                            for (j = 0; j < num_ranks; j++) {
+                                rngs[i].ranks[j] = base_rank+j;
+                            }
+                        } else {
+                            TEST_ERROR(("%s:%d: Can't parse --ns-dist value in order to get ranks for namespace %s", my_nspace, my_rank, rngs[i].nspace));
+                            PMIX_RANGE_FREE(rngs, nranges);
+                            PMIX_LIST_DESTRUCT(&test_fences);
+                            return PMIX_ERROR;
+                        }
+                    }
+                }
+                for (j = 0; j < rngs[i].nranks; j++) {
+                    snprintf(sval, 50, "%s:%d", rngs[i].nspace, rngs[i].ranks[j]);
+                    fprintf(stderr, "%s:%d want to get from %s:%d key %s val %s\n", my_nspace, my_rank, rngs[i].nspace, rngs[i].ranks[j], key, sval);
+                    if (PMIX_SUCCESS != (rc = PMIx_Get(rngs[i].nspace, rngs[i].ranks[j], key, &val))) {//+params.base_rank
+                        TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, rngs[i].nspace, rngs[i].ranks[j]));
+                        PMIX_RANGE_FREE(rngs, nranges);
+                        PMIX_LIST_DESTRUCT(&test_fences);
+                        return rc;
+                    }
+                    if (val->type != PMIX_STRING || strcmp(val->data.string, sval)) {
+                        TEST_ERROR(("%s:%d:  Key %s value or type mismatch, wait %s(%d) get %s(%d) from %s:%d",
+                                    my_nspace, my_rank, key, sval, PMIX_STRING, val->data.string, val->type, rngs[i].nspace, rngs[i].ranks[j]));
+                        PMIX_VALUE_RELEASE(val);
+                        PMIX_RANGE_FREE(rngs, nranges);
+                        PMIX_LIST_DESTRUCT(&test_fences);
+                        return PMIX_ERROR;
+                    }
+                    TEST_VERBOSE(("%s:%d: GET OF %s SUCCEEDED from %s:%d", my_nspace, my_rank, key, rngs[i].nspace, rngs[i].ranks[j]));
+                    PMIX_VALUE_RELEASE(val);
+                }
             }
         }
-        fprintf(stderr,"tmp = %s\n",  tmp);
+        PMIX_RANGE_FREE(rngs, nranges);
+        fence_num++;
     }
     PMIX_LIST_DESTRUCT(&test_fences);
-    return 0;
+    return PMIX_SUCCESS;
 }

--- a/test/test_fence.h
+++ b/test/test_fence.h
@@ -1,3 +1,6 @@
+#include <time.h>
 #include "test_common.h"
+#include "src/api/pmix_common.h"
+#include "src/api/pmix.h"
 
-int test_fence(test_params params, int my_nspace, int my_rank);
+int test_fence(test_params params, char *my_nspace, int my_rank);

--- a/test/utils.c
+++ b/test/utils.c
@@ -91,6 +91,10 @@ void set_client_argv(test_params *params, char ***argv)
         pmix_argv_append_nosize(argv, "--noise");
         pmix_argv_append_nosize(argv, params->noise);
     }
+    if (NULL != params->ns_dist) {
+        pmix_argv_append_nosize(argv, "--ns-dist");
+        pmix_argv_append_nosize(argv, params->ns_dist);
+    }
 
 }
 


### PR DESCRIPTION
Currently tests fail with direct modex (fence with no data exchange) and when ranges array passed as a fence parameter. I will investigate this further.
* Added noise to fence tests: --noise option with similar to --fence format [0:0;1:1-3] specifies ranks which should sleep several seconds before doing fence test.
Using this --noise option sometimes make fence test pass even when anges array passed as a fence parameter.