### PR TITLE
pmix tests: added testing some different data types

### DIFF
--- a/src/api/pmix_common.h.in
+++ b/src/api/pmix_common.h.in
@@ -696,6 +696,19 @@ const char* PMIx_Get_version(void);
 #define PMIX_VAL_SET(_v, _field, _val )   \
     PMIX_VAL_SET_ ## _field(_v, _field, _val)
 
+#define PMIX_VAL_cmp_val(_val1, _val2)      ((_val1) != (_val2))
+#define PMIX_VAL_cmp_float(_val1, _val2)    (abs((_val1) - (_val2)) > 0.000001)
+#define PMIX_VAL_cmp_ptr(_val1, _val2)      strncmp(_val1, _val2, strlen(_val1)+1)
+
+#define PMIX_VAL_CMP_int     PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_uint32_t     PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_uint16_t     PMIX_VAL_cmp_val
+#define PMIX_VAL_CMP_float     PMIX_VAL_cmp_float
+#define PMIX_VAL_CMP_string     PMIX_VAL_cmp_ptr
+
+#define PMIX_VAL_CMP(_field, _val1, _val2) \
+    PMIX_VAL_CMP_ ## _field(_val1, _val2)
+
 #define PMIX_VAL_FREE(_v) \
      PMIx_free_value_data(_v)
 

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -34,104 +34,12 @@
 #include "test_common.h"
 #include "test_fence.h"
 
-static int get_local_peers(int **_peers, int *count)
-{
-    pmix_value_t *val;
-    int *peers = NULL;
-    char *sptr, *token, *eptr, *str;
-    int npeers;
-    char nspace[PMIX_MAX_VALLEN];
-    int rank, rc;
-
-    /* To get namespace and rank */
-    if (PMIX_SUCCESS != (rc = PMIx_Init(nspace, &rank))) {
-        TEST_ERROR(("rank %d: PMIx_Init failed: %d", rank, rc));
-        return rc;
-    }
-    /* to keep reference counter consistent */
-    PMIx_Finalize();
-
-    /* get number of neighbours on this node */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(nspace, rank, PMIX_LOCAL_SIZE, &val))) {
-        TEST_ERROR(("rank %d: PMIx_Get local peer # failed: %d", rank, rc));
-        return rc;
-    }
-    if (NULL == val) {
-        TEST_ERROR(("rank %d: PMIx_Get local peer # returned NULL value", rank));
-        return PMIX_ERROR;
-    }
-
-    if (val->type != PMIX_UINT32  ) {
-        TEST_ERROR(("rank %d: local peer # attribute value type mismatch,"
-                " want %d get %d(%d)",
-                rank, PMIX_UINT32, val->type));
-        return PMIX_ERROR;
-    }
-    npeers = val->data.uint32;
-    peers = malloc(sizeof(int) * npeers);
-
-    /* get ranks of neighbours on this node */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(nspace, rank, PMIX_LOCAL_PEERS, &val))) {
-        TEST_ERROR(("rank %d: PMIx_Get local peers failed: %d", rank, rc));
-        return rc;
-    }
-    if (NULL == val) {
-        TEST_ERROR(("rank %d: PMIx_Get local peers returned NULL value", rank));
-        return PMIX_ERROR;
-    }
-
-    if (val->type != PMIX_STRING  ) {
-        TEST_ERROR(("rank %d: local peers attribute value type mismatch,"
-                " want %d get %d(%d)",
-                rank, PMIX_UINT32, val->type));
-        return PMIX_ERROR;
-    }
-
-    *count = 0;
-    sptr = NULL;
-    str = val->data.string;
-    do{
-        if( *count > npeers ){
-            TEST_ERROR(("rank %d: Bad peer ranks number: should be %d, actual %d (%s)",
-                rank, npeers, *count, val->data.string));
-            return PMIX_ERROR;
-        }
-        token = strtok_r(str, ",", &sptr);
-        str = NULL;
-        if( NULL != token ){
-            peers[(*count)++] = strtol(token,&eptr,10);
-            if( *eptr != '\0' ){
-                TEST_ERROR(("rank %d: Bad peer ranks string", rank));
-                return PMIX_ERROR;
-            }
-        }
-
-    } while( NULL != token );
-
-    if( *count != npeers ){
-        TEST_ERROR(("rank %d: Bad peer ranks number: should be %d, actual %d (%s)",
-                rank, npeers, *count, val->data.string));
-        return PMIX_ERROR;
-    }
-
-    *_peers = peers;
-    return PMIX_SUCCESS;
-}
-
-static void release_cb(pmix_status_t status, void *cbdata)
-{
-    int *ptr = (int*)cbdata;
-    *ptr = 0;
-}
-
 int main(int argc, char **argv)
 {
     char nspace[PMIX_MAX_VALLEN];
     int rank;
-    int rc, i, j;
+    int rc;
     pmix_value_t value;
-    char key[50], sval[50];
-    int *peers, npeers;
     pmix_value_t *val = &value;
     test_params params;
     INIT_TEST_PARAMS(params);
@@ -184,6 +92,12 @@ int main(int argc, char **argv)
 
     TEST_VERBOSE(("rank %d: Universe size check: PASSED", rank));
 
+    if( NULL != params.nspace && 0 != strcmp(nspace, params.nspace) ) {
+        TEST_ERROR(("rank %d: Bad nspace!", rank));
+        FREE_TEST_PARAMS(params);
+        exit(0);
+    }
+
     if (NULL != params.fences) {
         rc = test_fence(params, params.nspace, rank);
         if (PMIX_SUCCESS != rc) {
@@ -192,166 +106,10 @@ int main(int argc, char **argv)
         }
     }
 
-    if( NULL != params.nspace && 0 != strcmp(nspace, params.nspace) ) {
-        TEST_ERROR(("rank %d: Bad nspace!", rank));
+    rc = test_job_fence(params, params.nspace, rank);
+    if (PMIX_SUCCESS != rc) {
         FREE_TEST_PARAMS(params);
         exit(0);
-    }
-
-    for (i=0; i < 3; i++) {
-        (void)snprintf(key, 50, "local-key-%d", i);
-        PMIX_VAL_SET(&value, int, 12340 + i);
-        if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, key, &value))) {
-            TEST_ERROR(("rank %d: PMIx_Put failed: %d", rank, rc));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-
-        (void)snprintf(key, 50, "remote-key-%d", i);
-        (void)snprintf(sval, 50, "Test string #%d", i);
-        PMIX_VAL_SET(&value, string, sval);
-        if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, key, &value))) {
-            TEST_ERROR(("rank %d: PMIx_Put failed: %d", rank, rc));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-        PMIX_VALUE_DESTRUCT(&value);
-
-        (void)snprintf(key, 50, "global-key-%d", i);
-        PMIX_VAL_SET(&value, float, 12.15 + i);
-        if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
-            TEST_ERROR(("rank %d: PMIx_Put failed: %d", rank, rc));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-    }
-
-    /* Submit the data */
-    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-        TEST_ERROR(("rank %d: PMIx_Commit failed: %d", rank, rc));
-        FREE_TEST_PARAMS(params);
-        exit(0);
-    }
-
-    /* Perform a fence if was requested */
-    if( !params.nonblocking ){
-        if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, 1))) {
-            TEST_ERROR(("rank %d: PMIx_Fence failed: %d", rank, rc));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-    } else {
-        int in_progress = 1, count;
-        if ( PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, params.collect, release_cb, &in_progress))) {
-            TEST_ERROR(("rank %d: PMIx_Fence failed: %d", rank, rc));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-
-        count = 0;
-        while( in_progress ){
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100;
-            nanosleep(&ts,NULL);
-            count++;
-
-        }
-        TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs", count*100*1E-9));
-    }
-    TEST_VERBOSE(("rank %d: Fence successfully completed", rank));
-
-    if (PMIX_SUCCESS != (rc = get_local_peers(&peers, &npeers))) {
-        FREE_TEST_PARAMS(params);
-        exit(0);
-    }
-
-    /* Check the predefined output */
-    for (i=0; i < (int)params.ns_size; i++) {
-
-        for (j=0; j < 3; j++) {
-
-            int local = 0, k;
-            for(k=0; k<npeers; k++){
-                if( peers[k] == i+params.base_rank){
-                    local = 1;
-                }
-            }
-            if( local ){
-                sprintf(key,"local-key-%d",j);
-                if (PMIX_SUCCESS != (rc = PMIx_Get(nspace, i+params.base_rank, key, &val))) {
-                    TEST_ERROR(("rank %d: PMIx_Get failed: %d", rank, rc));
-                    FREE_TEST_PARAMS(params);
-                    exit(0);
-                }
-                if (NULL == val) {
-                    TEST_ERROR(("rank %d: PMIx_Get returned NULL value", rank));
-                    FREE_TEST_PARAMS(params);
-                    exit(0);
-                }
-                if (val->type != PMIX_INT || val->data.integer != (12340+j)) {
-                    TEST_ERROR(("rank %d: Key %s value or type mismatch,"
-                            " want %d(%d) get %d(%d)",
-                            rank, key, (12340+j), PMIX_INT,
-                            val->data.integer, val->type));
-                    FREE_TEST_PARAMS(params);
-                    exit(0);
-                }
-                TEST_VERBOSE(("rank %d: GET OF %s SUCCEEDED", rank, key));
-                PMIX_VALUE_RELEASE(val);
-            }
-
-            sprintf(key,"remote-key-%d",j);
-            sprintf(sval,"Test string #%d",j);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(nspace, i+params.base_rank, key, &val))) {
-                TEST_ERROR(("rank %d: PMIx_Get failed (%d)", rank, rc));
-                FREE_TEST_PARAMS(params);
-                exit(0);
-            }
-            if (val->type != PMIX_STRING || strcmp(val->data.string, sval)) {
-                TEST_ERROR(("rank %d:  Key %s value or type mismatch, wait %s(%d) get %s(%d)",
-                            rank, key, sval, PMIX_STRING, val->data.string, val->type));
-                FREE_TEST_PARAMS(params);
-                exit(0);
-            }
-            TEST_VERBOSE(("rank %d: GET OF %s SUCCEEDED", rank, key));
-            PMIX_VALUE_RELEASE(val);
-
-            sprintf(key, "global-key-%d", j);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(nspace, i+params.base_rank, key, &val))) {
-                TEST_ERROR(("rank %d: PMIx_Get failed (%d)", rank, rc));
-                FREE_TEST_PARAMS(params);
-                exit(0);
-            }
-            if (val->type != PMIX_FLOAT || val->data.fval != (float)12.15 + j) {
-                TEST_ERROR(("rank %d [ERROR]: Key %s value or type mismatch,"
-                            " wait %f(%d) get %f(%d)",
-                            rank, key, ((float)10.15 + i), PMIX_FLOAT,
-                            val->data.fval, val->type));
-                FREE_TEST_PARAMS(params);
-                exit(0);
-            }
-            PMIX_VALUE_RELEASE(val);
-            TEST_VERBOSE(("rank %d: GET OF %s SUCCEEDED", rank, key));
-        }
-
-        /* ask for a non-existent key */
-        if (PMIX_SUCCESS == (rc = PMIx_Get(nspace, i+params.base_rank, "foobar", &val))) {
-            TEST_ERROR(("rank %d: PMIx_Get returned success instead of failure",
-                        rank));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-        if (PMIX_ERR_NOT_FOUND != rc) {
-            TEST_ERROR(("rank %d [ERROR]: PMIx_Get returned %d instead of not_found",
-                        rank, rc));
-        }
-        if (NULL != val) {
-            TEST_ERROR(("rank %d [ERROR]: PMIx_Get did not return NULL value", rank));
-            FREE_TEST_PARAMS(params);
-            exit(0);
-        }
-        TEST_VERBOSE(("rank %d: rank %d is OK", rank, i+params.base_rank));
     }
 
     TEST_VERBOSE(("Client ns %s rank %d: PASSED", params.nspace, rank));

--- a/test/test_fence.c
+++ b/test/test_fence.c
@@ -69,6 +69,67 @@ static int get_all_ranks_from_namespace(test_params params, char *nspace, int **
     return PMIX_SUCCESS;
 }
 
+#define PUT(dtype, data, flag, fence_num, ind) do {                                                                 \
+    char key[50];                                                                                                   \
+    pmix_value_t value;                                                                                             \
+    (void)snprintf(key, 50, "key-f%d:%d", fence_num, ind);                                                          \
+    PMIX_VAL_SET(&value, dtype, data);                                                                              \
+    fprintf(stderr, "%s:%d put key %s\n", my_nspace, my_rank, key);                                                 \
+    if (PMIX_SUCCESS != (rc = PMIx_Put(flag, key, &value))) {                                                       \
+        TEST_ERROR(("%s:%d: PMIx_Put key %s failed: %d", my_nspace, my_rank, key, rc));                             \
+        rc = PMIX_ERROR;                                                                                            \
+    }                                                                                                               \
+    PMIX_VALUE_DESTRUCT(&value);                                                                                    \
+} while (0);
+
+#define GET(dtype, data, ns, rank, fence_num, ind) do {                                                             \
+    char key[50];                                                                                                   \
+    pmix_value_t value;                                                                                             \
+    pmix_value_t *val = &value;                                                                                     \
+    sprintf(key,"key-f%d:%d", fence_num, ind);                                                                      \
+    fprintf(stderr, "%s:%d want to get from %s:%d key %s\n", my_nspace, my_rank, ns, rank, key);                    \
+    if (PMIX_SUCCESS != (rc = PMIx_Get(ns, rank, key, &val))) {                                                     \
+        TEST_ERROR(("%s:%d: PMIx_Get failed: %d from %s:%d", my_nspace, my_rank, rc, ns, rank));                    \
+        rc = PMIX_ERROR;                                                                                            \
+    }                                                                                                               \
+    else if (NULL == val) {                                                                                         \
+        TEST_ERROR(("%s:%d: PMIx_Get returned NULL value", my_nspace, my_rank));                                    \
+        rc = PMIX_ERROR;                                                                                            \
+    }                                                                                                               \
+    else if (val->type != PMIX_VAL_TYPE_ ## dtype || PMIX_VAL_CMP(dtype, PMIX_VAL_FIELD_ ## dtype((val)), data)) {  \
+        TEST_ERROR(("%s:%d: Key %s value or type mismatch,"                                                         \
+                    " want type %d get type %d",                                                                    \
+                    my_nspace, my_rank, key, PMIX_VAL_TYPE_ ## dtype, val->type));                                  \
+        rc = PMIX_ERROR;                                                                                            \
+    }                                                                                                               \
+    if (PMIX_SUCCESS == rc) {                                                                                       \
+        TEST_VERBOSE(("%s:%d: GET OF %s from %s:%d SUCCEEDED", my_nspace, my_rank, key, ns, rank));                 \
+    }                                                                                                               \
+    PMIX_VALUE_RELEASE(val);                                                                                        \
+} while(0);
+
+#define FENCE(blocking, data_ex, rngs, nranges) do {                                                                \
+    if( blocking ){                                                                                                 \
+        rc = PMIx_Fence(rngs, nranges, data_ex);                                                                    \
+    } else {                                                                                                        \
+        int in_progress = 1, count;                                                                                 \
+        if ( PMIX_SUCCESS == (rc = PMIx_Fence_nb(rngs, nranges, data_ex, release_cb, &in_progress))) {              \
+            count = 0;                                                                                              \
+            while( in_progress ){                                                                                   \
+                struct timespec ts;                                                                                 \
+                ts.tv_sec = 0;                                                                                      \
+                ts.tv_nsec = 100;                                                                                   \
+                nanosleep(&ts,NULL);                                                                                \
+                count++;                                                                                            \
+            }                                                                                                       \
+            TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs", count*100*1E-9));                      \
+        }                                                                                                           \
+    }                                                                                                               \
+    if (PMIX_SUCCESS == rc) {                                                                                       \
+        TEST_VERBOSE(("%s:%d: Fence successfully completed", my_nspace, my_rank));                                  \
+    }                                                                                                               \
+} while (0);
+
 int test_fence(test_params params, char *my_nspace, int my_rank)
 {
     int len;
@@ -82,9 +143,8 @@ int test_fence(test_params params, char *my_nspace, int my_rank)
     int n = 0, r = 0;
     int participate = 0;
     int fence_num = 0;
-    pmix_value_t value;
-    char key[50], sval[50];
-    pmix_value_t *val = &value;
+    char sval[50];
+    int put_ind;
 
     if (NULL != params.noise) {
         add_noise(params.noise, my_nspace, my_rank);
@@ -99,6 +159,7 @@ int test_fence(test_params params, char *my_nspace, int my_rank)
         char tmp[256] = {0};
         len = sprintf(tmp, "fence %d: block = %d de = %d ", fence_num, desc->blocking, desc->data_exchange);
         n = 0;
+        participate = 0;
         PMIX_LIST_FOREACH(ndesc, &(desc->range->nspaces), nspace_desc_t) {
             (void)snprintf(rngs[n].nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, ndesc->id);
             rngs[n].nranks = pmix_list_get_size(&(ndesc->ranks));
@@ -129,17 +190,47 @@ int test_fence(test_params params, char *my_nspace, int my_rank)
         if (1 == participate) {
             /*run fence test on this range */
             /* first put value (my_ns, my_rank) with key based on fence_num to split results of different fences*/
-            (void)snprintf(key, 50, "key-f%d", fence_num);
+            put_ind = 0;
             (void)snprintf(sval, 50, "%s:%d", my_nspace, my_rank);
-            fprintf(stderr, "%s:%d put key %s val %s\n", my_nspace, my_rank, key, sval);
-            PMIX_VAL_SET(&value, string, sval);
-            if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
+            PUT(string, sval, PMIX_GLOBAL, fence_num, put_ind++);
+            if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
                 PMIX_RANGE_FREE(rngs, nranges);
                 PMIX_LIST_DESTRUCT(&test_fences);
                 return rc;
             }
-            PMIX_VALUE_DESTRUCT(&value);
+
+            PUT(int, my_rank, PMIX_GLOBAL, fence_num, put_ind++);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
+            }
+
+            PUT(float, 1.1, PMIX_GLOBAL, fence_num, put_ind++);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
+            }
+
+            PUT(uint32_t, 14, PMIX_GLOBAL, fence_num, put_ind++);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
+            }
+
+            PUT(uint16_t, 15, PMIX_GLOBAL, fence_num, put_ind++);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
+            }
 
             /* Submit the data */
             if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
@@ -150,33 +241,13 @@ int test_fence(test_params params, char *my_nspace, int my_rank)
             }
 
             /* perform fence */
-            if( desc->blocking ){
-                if (PMIX_SUCCESS != (rc = PMIx_Fence(rngs, nranges, desc->data_exchange))) {
-                    TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-                    PMIX_RANGE_FREE(rngs, nranges);
-                    PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
-                }
-            } else {
-                int in_progress = 1, count;
-                if ( PMIX_SUCCESS != (rc = PMIx_Fence_nb(rngs, nranges, desc->data_exchange, release_cb, &in_progress))) {
-                    TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-                    PMIX_RANGE_FREE(rngs, nranges);
-                    PMIX_LIST_DESTRUCT(&test_fences);
-                    return rc;
-                }
-
-                count = 0;
-                while( in_progress ){
-                    struct timespec ts;
-                    ts.tv_sec = 0;
-                    ts.tv_nsec = 100;
-                    nanosleep(&ts,NULL);
-                    count++;
-                }
-                TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs", count*100*1E-9));
+            FENCE(desc->blocking, desc->data_exchange, rngs, nranges);
+            if (PMIX_SUCCESS != rc) {
+                TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+                PMIX_RANGE_FREE(rngs, nranges);
+                PMIX_LIST_DESTRUCT(&test_fences);
+                return rc;
             }
-            TEST_VERBOSE(("%s:%d: Fence successfully completed", my_nspace, my_rank));
 
             /* get data from all participating in this fence clients */
             for (i = 0; i < nranges; i++ ) {
@@ -193,24 +264,43 @@ int test_fence(test_params params, char *my_nspace, int my_rank)
                     }
                 }
                 for (j = 0; j < rngs[i].nranks; j++) {
+                    put_ind = 0;
                     snprintf(sval, 50, "%s:%d", rngs[i].nspace, rngs[i].ranks[j]);
-                    fprintf(stderr, "%s:%d want to get from %s:%d key %s val %s\n", my_nspace, my_rank, rngs[i].nspace, rngs[i].ranks[j], key, sval);
-                    if (PMIX_SUCCESS != (rc = PMIx_Get(rngs[i].nspace, rngs[i].ranks[j], key, &val))) {//+params.base_rank
+                    GET(string, sval, rngs[i].nspace, rngs[i].ranks[j], fence_num, put_ind++);
+                    if (PMIX_SUCCESS != rc) {
                         TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, rngs[i].nspace, rngs[i].ranks[j]));
                         PMIX_RANGE_FREE(rngs, nranges);
                         PMIX_LIST_DESTRUCT(&test_fences);
                         return rc;
                     }
-                    if (val->type != PMIX_STRING || strcmp(val->data.string, sval)) {
-                        TEST_ERROR(("%s:%d:  Key %s value or type mismatch, wait %s(%d) get %s(%d) from %s:%d",
-                                    my_nspace, my_rank, key, sval, PMIX_STRING, val->data.string, val->type, rngs[i].nspace, rngs[i].ranks[j]));
-                        PMIX_VALUE_RELEASE(val);
+                    GET(int, rngs[i].ranks[j], rngs[i].nspace, rngs[i].ranks[j], fence_num, put_ind++);
+                    if (PMIX_SUCCESS != rc) {
+                        TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, rngs[i].nspace, rngs[i].ranks[j]));
                         PMIX_RANGE_FREE(rngs, nranges);
                         PMIX_LIST_DESTRUCT(&test_fences);
-                        return PMIX_ERROR;
+                        return rc;
                     }
-                    TEST_VERBOSE(("%s:%d: GET OF %s SUCCEEDED from %s:%d", my_nspace, my_rank, key, rngs[i].nspace, rngs[i].ranks[j]));
-                    PMIX_VALUE_RELEASE(val);
+                    GET(float, 1.1, rngs[i].nspace, rngs[i].ranks[j], fence_num, put_ind++);
+                    if (PMIX_SUCCESS != rc) {
+                        TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, rngs[i].nspace, rngs[i].ranks[j]));
+                        PMIX_RANGE_FREE(rngs, nranges);
+                        PMIX_LIST_DESTRUCT(&test_fences);
+                        return rc;
+                    }
+                    GET(uint32_t, 14, rngs[i].nspace, rngs[i].ranks[j], fence_num, put_ind++);
+                    if (PMIX_SUCCESS != rc) {
+                        TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, rngs[i].nspace, rngs[i].ranks[j]));
+                        PMIX_RANGE_FREE(rngs, nranges);
+                        PMIX_LIST_DESTRUCT(&test_fences);
+                        return rc;
+                    }
+                    GET(uint16_t, 15, rngs[i].nspace, rngs[i].ranks[j], fence_num, put_ind++);
+                    if (PMIX_SUCCESS != rc) {
+                        TEST_ERROR(("%s:%d: PMIx_Get failed (%d) from %s:%d", my_nspace, my_rank, rc, rngs[i].nspace, rngs[i].ranks[j]));
+                        PMIX_RANGE_FREE(rngs, nranges);
+                        PMIX_LIST_DESTRUCT(&test_fences);
+                        return rc;
+                    }
                 }
             }
         }
@@ -299,30 +389,26 @@ int test_job_fence(test_params params, char *my_nspace, int my_rank)
 {
     int rc;
     int i, j;
-    char key[50], sval[50];
+    char sval[50];
     int *peers, npeers;
     pmix_value_t value;
     pmix_value_t *val = &value;
     for (i=0; i < 3; i++) {
-        (void)snprintf(key, 50, "local-key-%d", i);
-        PMIX_VAL_SET(&value, int, 12340 + i);
-        if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_LOCAL, key, &value))) {
+        PUT(int, 12340 + i, PMIX_LOCAL, 0, i);
+        if (PMIX_SUCCESS != rc) {
+            TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
+            return rc;
+        }
+
+        (void)snprintf(sval, 50, "%s:%d", my_nspace, my_rank);
+        PUT(string, sval, PMIX_REMOTE, 1, i);
+        if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
             return PMIX_ERROR;
         }
 
-        (void)snprintf(key, 50, "remote-key-%d", i);
-        (void)snprintf(sval, 50, "Test string #%d", i);
-        PMIX_VAL_SET(&value, string, sval);
-        if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, key, &value))) {
-            TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
-            return PMIX_ERROR;
-        }
-        PMIX_VALUE_DESTRUCT(&value);
-
-        (void)snprintf(key, 50, "global-key-%d", i);
-        PMIX_VAL_SET(&value, float, 12.15 + i);
-        if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, key, &value))) {
+        PUT(float, (float)12.15 + i, PMIX_GLOBAL, 2, i);
+        if (PMIX_SUCCESS != rc) {
             TEST_ERROR(("%s:%d: PMIx_Put failed: %d", my_nspace, my_rank, rc));
             return PMIX_ERROR;
         }
@@ -335,30 +421,11 @@ int test_job_fence(test_params params, char *my_nspace, int my_rank)
     }
 
     /* Perform a fence if was requested */
-    if( !params.nonblocking ){
-        if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, 1))) {
-            TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-            return PMIX_ERROR;
-        }
-    } else {
-        int in_progress = 1, count;
-        if ( PMIX_SUCCESS != (rc = PMIx_Fence_nb(NULL, 0, params.collect, release_cb, &in_progress))) {
-            TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
-            return PMIX_ERROR;
-        }
-
-        count = 0;
-        while( in_progress ){
-            struct timespec ts;
-            ts.tv_sec = 0;
-            ts.tv_nsec = 100;
-            nanosleep(&ts,NULL);
-            count++;
-
-        }
-        TEST_VERBOSE(("PMIx_Fence_nb(barrier,collect): free time: %lfs", count*100*1E-9));
+    FENCE(!params.nonblocking, params.collect, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        TEST_ERROR(("%s:%d: PMIx_Fence failed: %d", my_nspace, my_rank, rc));
+        return rc;
     }
-    TEST_VERBOSE(("%s:%d: Fence successfully completed", my_nspace, my_rank));
 
     if (PMIX_SUCCESS != (rc = get_local_peers(my_nspace, my_rank, &peers, &npeers))) {
         return PMIX_ERROR;
@@ -376,54 +443,25 @@ int test_job_fence(test_params params, char *my_nspace, int my_rank)
                 }
             }
             if( local ){
-                sprintf(key,"local-key-%d",j);
-                if (PMIX_SUCCESS != (rc = PMIx_Get(my_nspace, i+params.base_rank, key, &val))) {
+                GET(int, (12340+j), my_nspace, i+params.base_rank, 0, j);
+                if (PMIX_SUCCESS != rc) {
                     TEST_ERROR(("%s:%d: PMIx_Get failed: %d", my_nspace, my_rank, rc));
                     return PMIX_ERROR;
                 }
-                if (NULL == val) {
-                    TEST_ERROR(("%s:%d: PMIx_Get returned NULL value", my_nspace, my_rank));
-                    return PMIX_ERROR;
-                }
-                if (val->type != PMIX_INT || val->data.integer != (12340+j)) {
-                    TEST_ERROR(("%s:%d: Key %s value or type mismatch,"
-                            " want %d(%d) get %d(%d)",
-                            my_nspace, my_rank, key, (12340+j), PMIX_INT,
-                            val->data.integer, val->type));
-                    return PMIX_ERROR;
-                }
-                TEST_VERBOSE(("%s:%d: GET OF %s SUCCEEDED", my_nspace, my_rank, key));
-                PMIX_VALUE_RELEASE(val);
             }
 
-            sprintf(key,"remote-key-%d",j);
-            sprintf(sval,"Test string #%d",j);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(my_nspace, i+params.base_rank, key, &val))) {
+            snprintf(sval, 50, "%s:%d", my_nspace, i+params.base_rank);
+            GET(string, sval, my_nspace, i+params.base_rank, 1, j);
+            if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Get failed (%d)", my_nspace, my_rank, rc));
                 return PMIX_ERROR;
             }
-            if (val->type != PMIX_STRING || strcmp(val->data.string, sval)) {
-                TEST_ERROR(("%s:%d:  Key %s value or type mismatch, wait %s(%d) get %s(%d)",
-                            my_nspace, my_rank, key, sval, PMIX_STRING, val->data.string, val->type));
-                return PMIX_ERROR;
-            }
-            TEST_VERBOSE(("%s:%d: GET OF %s SUCCEEDED", my_nspace, my_rank, key));
-            PMIX_VALUE_RELEASE(val);
 
-            sprintf(key, "global-key-%d", j);
-            if (PMIX_SUCCESS != (rc = PMIx_Get(my_nspace, i+params.base_rank, key, &val))) {
+            GET(float, (float)12.15 + j, my_nspace, i+params.base_rank, 2, j);
+            if (PMIX_SUCCESS != rc) {
                 TEST_ERROR(("%s:%d: PMIx_Get failed (%d)", my_nspace, my_rank, rc));
                 return PMIX_ERROR;
             }
-            if (val->type != PMIX_FLOAT || val->data.fval != (float)12.15 + j) {
-                TEST_ERROR(("rank %d [ERROR]: Key %s value or type mismatch,"
-                            " wait %f(%d) get %f(%d)",
-                            my_nspace, my_rank, key, ((float)10.15 + i), PMIX_FLOAT,
-                            val->data.fval, val->type));
-                return PMIX_ERROR;
-            }
-            PMIX_VALUE_RELEASE(val);
-            TEST_VERBOSE(("%s:%d: GET OF %s SUCCEEDED", my_nspace, my_rank, key));
         }
 
         /* ask for a non-existent key */

--- a/test/test_fence.h
+++ b/test/test_fence.h
@@ -4,3 +4,4 @@
 #include "src/api/pmix.h"
 
 int test_fence(test_params params, char *my_nspace, int my_rank);
+int test_job_fence(test_params params, char *my_nspace, int my_rank);


### PR DESCRIPTION
Added service macros to pmix_common.h. They're used in tests to compare returned values with initial ones. Perhaps, these macros should be declared in test headers if they won't be used in the library itself.
@rhc54 Could you, please, take a look?