### PR TITLE
Few fixes.

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -251,7 +251,9 @@ int PMIx_Get_nb(const char *nspace, int rank,
          * the user requested. At this time, there is no way for the
          * key to eventually be found, so all we can do is return
          * the error */
-         PMIX_ERROR_LOG(rc);
+        pmix_output_verbose(2, pmix_globals.debug_output,
+                            "Error requesting key=%s for rank = %d, namespace = %s\n",
+                            key, rank, nm);
         return rc;
     }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -239,24 +239,6 @@ pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t PMIx_get_rendezvous_address(struct sockaddr_un *address, char **path)
-{
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:server get rendezvous address");
-
-    memcpy(address, &myaddress, sizeof(struct sockaddr_un));
-    if (NULL == path) {
-        return PMIX_SUCCESS;
-    }
-    /* return the URI itself */
-    if (NULL != myuri) {
-        *path = strdup(myuri);
-    } else {
-        *path = NULL;
-    }
-    return PMIX_SUCCESS;
-}
-
 static void cleanup_server_state(void)
 {
     int i;


### PR DESCRIPTION
1. Fix verbosive output when key wasn't found. This can be detectid in other ways.
2. Remove "lite" API artifacts.

Ralph, I've noticed that you replaced pmix_output_verbose back with the PMIX_ERROR_LOG. Do you have arguments for that? or it was unintentional?