### PR TITLE
configury: revamp PMI_CHECK_IDENT

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -138,12 +138,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     ############################################################################
     pmix_show_title "Compiler and preprocessor tests"
 
-    ##################################
-    # C compiler characteristics
-    ##################################
-    # Does the compiler support "ident"-like constructs?
-    PMIX_CHECK_IDENT([CC], [CFLAGS], [c], [C])
-
     #
     # Check for some types
     #

--- a/config/pmix_check_ident.m4
+++ b/config/pmix_check_ident.m4
@@ -80,18 +80,23 @@ EOF
     # resulting object file.  If the ident is found in "strings" or
     # the grep succeeds, rule that we have this flavor of ident.
 
-    PMIX_LOG_COMMAND([$pmix_compiler $pmix_flags -c conftest.$3 -o conftest.${OBJEXT}],
-                     [AS_IF([test -f conftest.${OBJEXT}],
-                            [pmix_output="`strings -a conftest.${OBJEXT} | grep $pmix_ident`"
-                             grep $pmix_ident conftest.${OBJEXT} 2>&1 1>/dev/null
-                             pmix_status=$?
-                             AS_IF([test "$pmix_output" != "" || test "$pmix_status" = "0"],
-                                   [$6],
-                                   [$7])],
-                            [PMIX_LOG_MSG([the failed program was:])
-                             PMIX_LOG_FILE([conftest.$3])
-                             $7]
-                            [$7])])
+    echo "configure:__oline__: $1" >&5
+    pmix_output=`$pmix_compiler $pmix_flags -c conftest.$3 -o conftest.${OBJEXT} 2>&1 1>/dev/null`
+    pmix_status=$?
+    AS_IF([test $pmix_status = 0],
+          [test -z "$pmix_output"
+           pmix_status=$?])
+    PMIX_LOG_MSG([\$? = $pmix_status], 1)
+    AS_IF([test $pmix_status = 0 && test -f conftest.${OBJEXT}],
+          [pmix_output="`strings -a conftest.${OBJEXT} | grep $pmix_ident`"
+           grep $pmix_ident conftest.${OBJEXT} 2>&1 1>/dev/null
+           pmix_status=$?
+           AS_IF([test "$pmix_output" != "" || test "$pmix_status" = "0"],
+                 [$6],
+                 [$7])],
+          [PMIX_LOG_MSG([the failed program was:])
+           PMIX_LOG_FILE([conftest.$3])
+           $7])
 
     unset pmix_compiler pmix_flags pmix_output pmix_status
     rm -rf conftest.* conftest${EXEEXT}

--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -297,6 +297,13 @@ AC_DEFUN([PMIX_SETUP_CC],[
     PMIX_ENSURE_CONTAINS_OPTFLAGS(["$CFLAGS"])
     AC_MSG_RESULT([$co_result])
     CFLAGS="$co_result"
+
+    ##################################
+    # C compiler characteristics
+    ##################################
+    # Does the compiler support "ident"-like constructs?
+    PMIX_CHECK_IDENT([CC], [CFLAGS], [c], [C])
+
 ])
 
 


### PR DESCRIPTION
bottom line, do not use '#ident ...' when configure'd with --enable-picky
to avoid useless warnings